### PR TITLE
fix: add globals to values schema

### DIFF
--- a/chart/mjs/values.schema.json
+++ b/chart/mjs/values.schema.json
@@ -1,6 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema#",
     "properties": {
+        "global": {
+            "type": "object",
+            "default": {}
+        },
         "additionalMatlabPVCs": {
             "type": "array",
             "items": {


### PR DESCRIPTION
Closes https://github.com/mathworks-ref-arch/matlab-parallel-server-on-kubernetes/issues/4
Allows to use `mjs` chart as a subchart